### PR TITLE
fix(sync): use provided branch

### DIFF
--- a/lua/rocks-git/operations.lua
+++ b/lua/rocks-git/operations.lua
@@ -142,7 +142,7 @@ operations.sync = nio.create(function(report_progress, report_error, pkg)
         end
     else
         report_progress(("rocks-git: Updating %s (unpinned)"):format(pkg.name))
-        local head_branch = git.get_head_branch(pkg)
+        local head_branch = pkg.branch or git.get_head_branch(pkg)
         local rev = git.get_rev(pkg)
         if head_branch ~= rev then
             pkg.rev = head_branch


### PR DESCRIPTION
Problem: 
if you set the branch to something other than the default branch, e.g.:
```toml
[plugins]
nvim-treesitter = { git = "nvim-treesitter/nvim-treesitter", branch = "main" }
```
`:Rocks sync` will checkout the default branch before pulling

Soluton:
use `pkg.branch` if provided or else get default branch