### PR TITLE
doc: explain that it defaults to recent tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,7 @@
 ## :star2: Summary
 
 `rocks-git.nvim` extends [`rocks.nvim`](https://github.com/nvim-neorocks/rocks-git.nvim)
-with the ability to install plugins into `packpath` directories ([`:h packages`](https://neovim.io/doc/user/repeat.html#packages))
-from git repositories.
+with the ability to install plugins from git repositories.
 
 It does so by hooking into the `:Rocks {install|update|sync|prune}` commands,
 allowing you to add `plugins` entries to your `rocks.toml` as follows:
@@ -75,7 +74,7 @@ Arguments:
 - `args`: (optional) `key=value` pairs, see [Configuration options](#configuration-options).
 
 If a plugin is not pinned to a revision or tag with the `rev` field,
-`:Rocks sync` will always update it to the latest remote revision.
+`:Rocks sync` will update to the most recent tag.
 
 ### Configuration options
 


### PR DESCRIPTION
Without further precision, rocks git will fetch the most recent tag. 

I removed the `packpath` reference which I think can make it confusing to users. The packpath reference is I suppose in contrast to rocks.nvim way of installing plugins but it's too technical to put right at the beginning. If we want to keep it, we could move it to `how it works` or `design` section. What do you think ?