### PR TITLE
feat!: always pin plugins on install and update

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -8,8 +8,9 @@ jobs:
   checks:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v22
+    - uses: actions/checkout@v4
+    - uses: DeterminateSystems/nix-installer-action@v10
+    - uses: cachix/cachix-action@v12
       with:
         name: neorocks
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
@@ -17,8 +18,8 @@ jobs:
   shell:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
-    - uses: cachix/install-nix-action@v22
+    - uses: actions/checkout@v4
+    - uses: DeterminateSystems/nix-installer-action@v10
     - uses: cachix/cachix-action@v12
       with:
         name: neorocks

--- a/.github/workflows/docgen.yaml
+++ b/.github/workflows/docgen.yaml
@@ -11,8 +11,8 @@ jobs:
     name: Generate docs
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v23
+      - uses: actions/checkout@v3
+      - uses: DeterminateSystems/nix-installer-action@v10
       - uses: cachix/cachix-action@v12
         with:
           name: neorocks

--- a/.github/workflows/review-checklist.yml
+++ b/.github/workflows/review-checklist.yml
@@ -20,6 +20,26 @@ jobs:
             const body = context.payload.pull_request.body
             if (body && body.startsWith(":robot: I have created a release *beep* *boop*")) { return; }
 
+            // Get a list of all issues created by the PR opener
+            // See: https://octokit.github.io/rest.js/#pagination
+            const creator = context.payload.sender.login
+            const opts = github.rest.issues.listForRepo.endpoint.merge({
+              ...context.issue,
+              creator,
+              state: 'all'
+            })
+            const issues = await github.paginate(opts)
+
+            for (const issue of issues) {
+              if (issue.number === context.issue.number) {
+                continue
+              }
+
+              if (issue.pull_request) {
+                return // Creator is already a contributor.
+              }
+            }
+
             const { data: comments } = await github.rest.issues.listComments({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/flake.lock
+++ b/flake.lock
@@ -1014,11 +1014,11 @@
     },
     "nixpkgs_10": {
       "locked": {
-        "lastModified": 1720721669,
-        "narHash": "sha256-1JeLwat5mfCTado8ZVKXg0v+1zf7sok3XCVKpd7+/2o=",
+        "lastModified": 1720424647,
+        "narHash": "sha256-fxNxyMY8yq6IoBIrBB6mncdk9BLO0RdEZ3CMVu1LOE8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "4b522ae0babb41e09e20bcdbd91fa2d07a2d0afc",
+        "rev": "6edd5cc7bd8eb73d2e7c2f05b34c04a7a4d02de9",
         "type": "github"
       },
       "original": {

--- a/flake.lock
+++ b/flake.lock
@@ -1012,6 +1012,21 @@
         "type": "github"
       }
     },
+    "nixpkgs_10": {
+      "locked": {
+        "lastModified": 1720721669,
+        "narHash": "sha256-1JeLwat5mfCTado8ZVKXg0v+1zf7sok3XCVKpd7+/2o=",
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "rev": "4b522ae0babb41e09e20bcdbd91fa2d07a2d0afc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nixos",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1719082008,
@@ -1192,9 +1207,7 @@
         "flake-parts": "flake-parts_7",
         "gen-luarc": "gen-luarc_2",
         "neorocks": "neorocks_2",
-        "nixpkgs": [
-          "nixpkgs"
-        ],
+        "nixpkgs": "nixpkgs_10",
         "pre-commit-hooks": "pre-commit-hooks_2"
       },
       "locked": {

--- a/flake.nix
+++ b/flake.nix
@@ -83,9 +83,7 @@
           hooks = {
             lua-ls = {
               enable = true;
-              settings = {
-                lua-ls.configuration = luarc;
-              };
+              settings.configuration = luarc;
             };
           };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -13,10 +13,7 @@
 
     gen-luarc.url = "github:mrcjkb/nix-gen-luarc-json";
 
-    rocks-nvim-flake = {
-      url = "github:nvim-neorocks/rocks.nvim";
-      inputs.nixpkgs.follows = "nixpkgs";
-    };
+    rocks-nvim-flake.url = "github:nvim-neorocks/rocks.nvim";
 
     flake-parts.url = "github:hercules-ci/flake-parts";
 
@@ -36,7 +33,7 @@
     pre-commit-hooks,
     ...
   }: let
-    name = "rocks.nvim";
+    name = "rocks-git.nvim";
 
     plugin-overlay = import ./nix/plugin-overlay.nix {
       inherit name self inputs;
@@ -63,6 +60,7 @@
           overlays = [
             neorocks.overlays.default
             gen-luarc.overlays.default
+            rocks-nvim-flake.overlays.default
             test-overlay
             plugin-overlay
           ];

--- a/lua/rocks-git/init.lua
+++ b/lua/rocks-git/init.lua
@@ -198,12 +198,16 @@ end, 1)
 rocks_git.get_update_callbacks = nio.create(function(mut_rocks_toml)
     ---@cast mut_rocks_toml MutRocksTomlRef
     local rocks_toml = rocks.get_rocks_toml() -- we cannot iterate over MutRocksTomlRef
-    return vim.iter(vim.tbl_values(rocks_toml.plugins))
+    return vim
+        .iter(vim.tbl_values(rocks_toml.plugins))
         :filter(function(spec)
             return type(spec.git) == "string"
         end)
         :map(mk_package)
-        :filter(git.is_outdated)
+        ---@param pkg Package
+        :filter(function(pkg)
+            return pkg.rev == nil or git.is_outdated(pkg)
+        end)
         :map(function(pkg)
             ---@cast pkg Package
             return nio.create(function(report_progress, report_error)

--- a/lua/rocks-git/init.lua
+++ b/lua/rocks-git/init.lua
@@ -206,7 +206,7 @@ rocks_git.get_update_callbacks = nio.create(function(mut_rocks_toml)
         :map(mk_package)
         ---@param pkg Package
         :filter(function(pkg)
-            return pkg.rev == nil or git.is_outdated(pkg)
+            return pkg.pin ~= true and (pkg.rev == nil or git.is_outdated(pkg))
         end)
         :map(function(pkg)
             ---@cast pkg Package

--- a/lua/rocks-git/operations.lua
+++ b/lua/rocks-git/operations.lua
@@ -69,7 +69,7 @@ operations.install = nio.create(function(report_progress, report_error, pkg)
     if pkg.rev then
         report_progress(("rocks-git: %s -> %s"):format(pkg.name, pkg.rev))
     else
-        report_progress(("rocks-git: %s"):format(pkg.name))
+        report_progress(("rocks-git: %s (Unpinned)"):format(pkg.name))
     end
     local future = git.clone(pkg)
     local ok = pcall(future.wait)
@@ -97,17 +97,19 @@ operations.install = nio.create(function(report_progress, report_error, pkg)
     return false
 end, 3)
 
----@type async fun(report_progress: fun(message: string), report_error: fun(message: string), pkg: Package)
+---@type async fun(report_progress: fun(message: string) | nil, report_error: fun(message: string), pkg: Package):boolean
 local update_pull = nio.create(function(report_progress, report_error, pkg)
     local future = git.pull(pkg)
     local ok = pcall(future.wait)
     if not ok then
         report_error(("rocks-git: Failed to pull %s"):format(pkg.name))
+        return ok
     end
     ok = build_if_required(report_progress, report_error, pkg)
-    if ok then
+    if ok and report_progress then
         report_progress(("rocks-git: Updated %s (unpinned)"):format(pkg.name))
     end
+    return ok
 end, 3)
 
 ---@type async fun(report_progress: fun(message: string), report_error: fun(message: string), pkg: Package)
@@ -127,46 +129,36 @@ end, 3)
 
 ---@type async fun(report_progress: fun(message: string), report_error: fun(message: string), pkg: Package)
 operations.sync = nio.create(function(report_progress, report_error, pkg)
-    if pkg.rev then
-        local rev = git.get_rev(pkg)
-        if rev == pkg.rev then
-            return
-        else
-            report_progress(("rocks-git: %s"):format(pkg.name))
-            local ok = update_to_rev(report_progress, report_error, pkg)
-            if ok and pkg.rev then
-                report_progress(("rocks-git: %s -> %s"):format(pkg.name, pkg.rev))
-            elseif ok then
-                report_progress(("rocks-git: Synced %s"):format(pkg.name))
-            end
-        end
+    if not pkg.rev then
+        return
+    end
+    local rev = git.get_rev(pkg)
+    if rev == pkg.rev then
+        return
     else
-        report_progress(("rocks-git: Updating %s (unpinned)"):format(pkg.name))
-        local head_branch = pkg.branch or git.get_head_branch(pkg)
-        local rev = git.get_rev(pkg)
-        if head_branch ~= rev then
-            pkg.rev = head_branch
-            local futureOpt = git.checkout(pkg)
-            if futureOpt and not pcall(futureOpt.wait) then
-                report_error(("rocks-git: Failed to checkout %s"):format(pkg.rev))
-                return
-            end
+        report_progress(("rocks-git: %s"):format(pkg.name))
+        local ok = update_to_rev(report_progress, report_error, pkg)
+        if ok and pkg.rev then
+            report_progress(("rocks-git: %s -> %s"):format(pkg.name, pkg.rev))
+        elseif ok then
+            report_progress(("rocks-git: Synced %s"):format(pkg.name))
         end
-        update_pull(report_progress, report_error, pkg)
     end
 end, 3)
 
 ---@type async fun(report_progress: fun(message: string), report_error: fun(message: string), pkg: Package): Package
 operations.update = nio.create(function(report_progress, report_error, pkg)
-    if not pkg.rev then
-        update_pull(report_progress, report_error, pkg)
-        return pkg
-    end
     local version_tuple = git.get_latest_remote_semver_tag(pkg.url).wait()
     ---@cast version_tuple tag_version_tuple
-    local prev = pkg.rev
+    local prev = pkg.rev or git.get_rev(pkg)
     pkg.rev = version_tuple[1]
-    local ok = update_to_rev(report_progress, report_error, pkg)
+    local ok
+    if not pkg.rev then
+        ok = update_pull(nil, report_error, pkg)
+        pkg.rev = git.get_rev(pkg)
+    else
+        ok = update_to_rev(report_progress, report_error, pkg)
+    end
     if ok then
         report_progress(("rocks-git: Updated %s: %s -> %s"):format(pkg.name, prev, pkg.rev))
         return pkg

--- a/nix/plugin-overlay.nix
+++ b/nix/plugin-overlay.nix
@@ -102,6 +102,7 @@ in {
     neovim-with-rocks
     ;
 
+  rocks-git-nvim = luajitPackages.rocks-git-nvim;
   vimPlugins =
     prev.vimPlugins
     // {

--- a/nix/plugin-overlay.nix
+++ b/nix/plugin-overlay.nix
@@ -26,6 +26,10 @@
     packageOverrides = luaPackage-override;
   };
   luajitPackages = prev.luajitPackages // final.luajit.pkgs;
+  lua5_1 = prev.lua5_1.override {
+    packageOverrides = luaPackage-override;
+  };
+  lua51Packages = prev.lua51Packages // final.lua5_1.pkgs;
 
   neovim-with-rocks = let
     rocks = inputs.rocks-nvim-flake.packages.${final.system}.rocks-nvim;
@@ -93,6 +97,8 @@ in {
   inherit
     luajit
     luajitPackages
+    lua5_1
+    lua51Packages
     neovim-with-rocks
     ;
 


### PR DESCRIPTION
Closes #36 

- Ignore unpinned packages on `sync` (unless they aren't installed).
  - This is in line with the behaviour of rocks.nvim when handling `scm` rocks.
- Add the `rev` to the rocks.toml entry on `install` and `update`.
  - This ensures that plugins managed by rocks-git.nvim should always be pinned to a revision or tag.