### PR TITLE
feat(experimental): install rockspec dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -112,6 +112,7 @@
             self.checks.${system}.pre-commit-check.enabledPackages
             ++ (with pkgs; [
               lua-language-server
+              docgen
             ])
             ++ oa.buildInputs;
           doCheck = false;

--- a/lua/rocks-git/git.lua
+++ b/lua/rocks-git/git.lua
@@ -36,7 +36,7 @@ local function git_cli(args, on_exit, opts)
 end
 
 ---Clones the package.
----@param pkg Package
+---@param pkg rocks-git.Package
 ---@param on_exit fun(sc: vim.SystemCompleted)|nil Called asynchronously when the git command exits.
 ---@param opts? vim.SystemOpts
 ---@return vim.SystemObj
@@ -51,7 +51,7 @@ local function clone(pkg, on_exit, opts)
 end
 
 ---Clones the package.
----@param pkg Package
+---@param pkg rocks-git.Package
 ---@return nio.control.Future
 function git.clone(pkg)
     local future = nio.control.future()
@@ -68,7 +68,7 @@ function git.clone(pkg)
 end
 
 ---Checks out the `rev` specified by the package, if one is specified.
----@param pkg Package
+---@param pkg rocks-git.Package
 ---@param on_exit fun(sc: vim.SystemCompleted)|nil Called asynchronously when the git command exits.
 ---@return vim.SystemObj | nil
 ---@see vim.system
@@ -80,7 +80,7 @@ local function checkout(pkg, on_exit)
 end
 
 ---Checks out the `rev` specified by the package, if one is specified.
----@param pkg Package
+---@param pkg rocks-git.Package
 ---@return nio.control.Future | nil future Returns `nil` if the package doesn't have a `rev` attribute
 function git.checkout(pkg)
     if not pkg.rev then
@@ -100,7 +100,7 @@ function git.checkout(pkg)
 end
 
 ---Fetches updates to the package
----@param pkg Package
+---@param pkg rocks-git.Package
 ---@param on_exit fun(sc: vim.SystemCompleted)|nil Called asynchronously when the git command exits.
 ---@return vim.SystemObj | nil
 ---@see vim.system
@@ -112,11 +112,11 @@ local function fetch(pkg, on_exit)
 end
 
 ---Checks out the `rev` specified by the package, if one is specified.
----@param pkg Package
+---@param pkg rocks-git.Package
 ---@return nio.control.Future
 function git.fetch(pkg)
     local future = nio.control.future()
-    ---@cast pkg Package
+    ---@cast pkg rocks-git.Package
     fetch(pkg, function(sc)
         ---@cast sc vim.SystemCompleted
         if sc.code == 0 then
@@ -130,7 +130,7 @@ function git.fetch(pkg)
 end
 
 ---Pulls the package
----@param pkg Package
+---@param pkg rocks-git.Package
 ---@param on_exit fun(sc: vim.SystemCompleted)|nil Called asynchronously when the git command exits.
 ---@return vim.SystemObj | nil
 ---@see vim.system
@@ -142,7 +142,7 @@ local function pull(pkg, on_exit)
 end
 
 ---Pulls the package
----@param pkg Package
+---@param pkg rocks-git.Package
 ---@return nio.control.Future
 function git.pull(pkg)
     local future = nio.control.future()
@@ -169,7 +169,7 @@ local function read_line(path)
     end
 end
 
----@param pkg Package
+---@param pkg rocks-git.Package
 ---@return string | nil rev The git hash or tag that is currently checked out
 function git.get_rev(pkg)
     local git_dir = vim.fs.joinpath(pkg.dir, ".git")
@@ -182,7 +182,7 @@ function git.get_rev(pkg)
     return tag or read_line(vim.fs.joinpath(git_dir, head_ref))
 end
 
----@param pkg Package
+---@param pkg rocks-git.Package
 ---@return string | nil head The remote HEAD branch name
 function git.get_head_branch(pkg)
     local git_dir = vim.fs.joinpath(pkg.dir, ".git")
@@ -225,9 +225,9 @@ function git.get_latest_remote_semver_tag(url)
     return future
 end
 
----@type async fun(pkg: Package):boolean
+---@type async fun(pkg: rocks-git.Package):boolean
 git.is_outdated = nio.create(function(pkg)
-    ---@cast pkg Package
+    ---@cast pkg rocks-git.Package
     local future = nio.control.future()
     if not pkg.rev then
         git_cli({ "status", "--untracked-files=no" }, function(sc)

--- a/lua/rocks-git/init.lua
+++ b/lua/rocks-git/init.lua
@@ -65,12 +65,12 @@ local nio = require("nio")
 ---@brief ]]
 
 ---@package
----@class Package: PackageSpec
+---@class rocks-git.Package: PackageSpec
 ---@field dir string
 ---@field url string
 
 ---@param spec PackageSpec
----@return Package
+---@return rocks-git.Package
 local function mk_package(spec)
     return vim.tbl_deep_extend("keep", {
         url = parser.parse_git_url(spec.git),
@@ -205,11 +205,11 @@ rocks_git.get_update_callbacks = nio.create(function(mut_rocks_toml)
             return type(spec.git) == "string"
         end)
         :map(mk_package)
-        ---@param pkg Package
+        ---@param pkg rocks-git.Package
         :filter(function(pkg)
             return pkg.pin ~= true and (pkg.rev == nil or git.is_outdated(pkg))
         end)
-        ---@param pkg Package
+        ---@param pkg rocks-git.Package
         :map(function(pkg)
             ---@param on_progress fun(msg: string)
             ---@param on_error fun(msg: string)

--- a/lua/rocks-git/rockspec.lua
+++ b/lua/rocks-git/rockspec.lua
@@ -1,0 +1,53 @@
+---@mod rocks-git.rockspec
+---
+---@brief [[
+---
+---Get dependencies from a rockspec in the repository root
+---
+---@brief ]]
+
+-- Copyright (C) 2024 Neorocks Org.
+--
+-- License:    GPLv3
+-- Created:    03 Sep 2024
+-- Updated:    03 Sep 2024
+-- Homepage:   https://github.com/nvim-neorocks/rocks-git.nvim
+-- Maintainer: mrcjkb <marc@jakobi.dev>
+
+local log = require("rocks.log")
+
+local rockspec = {}
+
+---@param pkg rocks-git.Package
+---@return string[]
+function rockspec.get_dependencies(pkg)
+    local rockspec_paths = vim.fs.find(function(name, path)
+        return pkg.dir == path
+            and vim
+                .iter({ "scm", "dev", "git" })
+                ---@param specrev string
+                :map(function(specrev)
+                    return pkg.name .. "%-" .. specrev .. "%-%d.rockspec"
+                end)
+                ---@param pattern string
+                :any(function(pattern)
+                    return name:match(pattern) ~= nil
+                end)
+    end, {
+        path = pkg.dir,
+        upward = false,
+    })
+    if vim.tbl_isempty(rockspec_paths) then
+        return {}
+    end
+    local rockspec_path = rockspec_paths[1]
+    local rockspec_tbl = {}
+    xpcall(function()
+        loadfile(rockspec_path, "t", rockspec_tbl)()
+    end, function(err)
+        log.error("rocks-git: Could not load rockspec: " .. err)
+    end)
+    return rockspec_tbl.dependencies or {}
+end
+
+return rockspec

--- a/spec/rockspec_spec.lua
+++ b/spec/rockspec_spec.lua
@@ -1,0 +1,29 @@
+local tempdir = vim.fn.tempname()
+local plugin_dir = vim.fs.joinpath(tempdir, "foo.nvim")
+vim.env.HOME = tempdir
+vim.system({ "rm", "-r", tempdir }):wait()
+vim.system({ "mkdir", "-p", plugin_dir }):wait()
+
+local rockspec = require("rocks-git.rockspec")
+describe("rockspec", function()
+    describe("get_dependencies", function()
+        local rockspec_content = [[
+package = "foo.nvim"
+version = "scm-1"
+
+dependencies = {
+  "bar >= 1.0.0",
+}
+]]
+        local fh = io.open(vim.fs.joinpath(plugin_dir, "foo.nvim-scm-1.rockspec"), "w+")
+        assert(fh, "Cound not open rockspec for writing")
+        fh:write(rockspec_content)
+        fh:close()
+        ---@diagnostic disable-next-line: missing-fields
+        local dependencies = rockspec.get_dependencies({
+            name = "foo.nvim",
+            dir = plugin_dir,
+        })
+        assert.same({ "bar >= 1.0.0" }, dependencies)
+    end)
+end)


### PR DESCRIPTION
See also: https://github.com/nvim-neorocks/rocks.nvim/pull/527

Requires an up-to-date rocks.nvim with the following experimental feature enabled:

```lua
vim.g.rocks_nvim = {
  -- ...
  experimental_features = {
    "ext_module_dependency_stubs",
  },
}
```