### PR TITLE
fix: `ignore_tags` field removed on update

### DIFF
--- a/lua/rocks-git/init.lua
+++ b/lua/rocks-git/init.lua
@@ -95,6 +95,8 @@ local function mut_update_rocks_toml(rocks_toml, spec)
     rocks_toml.plugins[spec.name].branch = spec.branch
     ---@diagnostic disable-next-line: inject-field
     rocks_toml.plugins[spec.name].build = spec.build
+    ---@diagnostic disable-next-line: inject-field
+    rocks_toml.plugins[spec.name].ignore_tags = spec.ignore_tags
 end
 
 ---@package


### PR DESCRIPTION
Fixes #71 