### PR TITLE
feat: show name of failing package

### DIFF
--- a/.github/workflows/checks.yaml
+++ b/.github/workflows/checks.yaml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: DeterminateSystems/nix-installer-action@v10
+    - uses: DeterminateSystems/nix-installer-action@v22
     - uses: cachix/cachix-action@v12
       with:
         name: lumen-labs
@@ -19,9 +19,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
-    - uses: DeterminateSystems/nix-installer-action@v10
+    - uses: DeterminateSystems/nix-installer-action@v22
     - uses: cachix/cachix-action@v12
       with:
         name: lumen-labs
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - run: nix build .#devShells.x86_64-linux.default -L --accept-flake-config 
+    - run: nix build .#devShells.x86_64-linux.default -L --accept-flake-config

--- a/doc/tags
+++ b/doc/tags
@@ -1,0 +1,5 @@
+PackageSpec	rocks-git.txt	/*PackageSpec*
+RocksGitConfig	rocks-git.txt	/*RocksGitConfig*
+rocks-git	rocks-git.txt	/*rocks-git*
+rocks-git.config	rocks-git.txt	/*rocks-git.config*
+rocks-git.contents	rocks-git.txt	/*rocks-git.contents*

--- a/lua/rocks-git/operations.lua
+++ b/lua/rocks-git/operations.lua
@@ -160,7 +160,7 @@ local update_to_rev = nio.create(function(on_progress, on_error, pkg)
     end
     local futureOpt = git.checkout(pkg)
     if futureOpt and not pcall(futureOpt.wait) then
-        on_error(("rocks-git: Failed to checkout %s"):format(pkg.rev))
+        on_error(("rocks-git: Failed to checkout %s %s"):format(pkg.name, pkg.rev))
     end
     ok = build_if_required(on_progress, on_error, pkg)
     return ok


### PR DESCRIPTION
With latest revision I get errors reported but it's hard to map it back to a specific plugin:

```
INFO | 2026-07-27 11:59:32.332 | .../site/pack/hm/start/rocks-git.nvim/lua/rocks-git/git.lua:38 | { "git", "fetch" }
INFO | 2026-07-27 11:59:32.755 | .../site/pack/hm/start/rocks-git.nvim/lua/rocks-git/git.lua:38 | { "git", "checkout", "v0.8.0", "--force", "--recurse-submodules" }
DEBUG | 2026-07-27 11:59:32.778 | ...m/start/rocks.nvim/lua/rocks/operations/helpers/init.lua:401 | Installing stubs is disabled
INFO | 2026-07-27 11:59:32.779 | .../site/pack/hm/start/rocks-git.nvim/lua/rocks-git/git.lua:38 | { "git", "fetch" }
INFO | 2026-07-27 11:59:33.206 | .../site/pack/hm/start/rocks-git.nvim/lua/rocks-git/git.lua:38 | { "git", "checkout", "v1.4.0", "--force", "--recurse-submodules" }
ERROR | 2026-07-27 11:59:33.226 | .../site/pack/hm/start/rocks-git.nvim/lua/rocks-git/git.lua:120 | {
  code = 128,
  signal = 0,
  stderr = "fatal : ce n'est pas un dépôt git : ../../../.git/modules/test/vendor/matcher_combinators.lua\nerreur : Le sous-module 'test/vendor/matcher_combinators.lua' n'a pas pu être mis à jour.\nerreur : Submodule 'test/vendor/matcher_combinators.lua' cannot checkout new HEAD.\n",
  stdout = ""
}
ERROR | 2026-07-27 11:59:33.227 | ...e/pack/hm/start/rocks.nvim/lua/rocks/operations/sync.lua:48 | SYNC ERROR: rocks-git: Failed to checkout v1.4.0
```

while now I have "baleaia.nvim" added to the last line:

```
ERROR | 2026-07-27 12:06:20.689 | ...e/pack/hm/start/rocks.nvim/lua/rocks/operations/sync.lua:48 | SYNC ERROR: rocks-git: Failed to checkout baleia.nvim v1.4.0
```