### PR TITLE
fix: dont warn when no remote tags exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,5 +39,6 @@ luac.out
 *.x86_64
 *.hex
 
+.pre-commit-config.yaml
 .luarc.json
 result*

--- a/lua/rocks-git/git.lua
+++ b/lua/rocks-git/git.lua
@@ -261,12 +261,17 @@ function git.get_latest_remote_semver_tag(url)
     get_latest_remote_version_tag(url, function(sc)
         ---@cast sc vim.SystemCompleted
         if sc.code == 0 then
-            local latest_tag, latest_version = parser.parse_git_latest_semver_tag(sc.stdout or "")
-            if latest_tag and latest_version then
-                future.set({ latest_tag, latest_version })
-            else
-                log.warn("Could not parse latest tag from: " .. sc.stdout)
+            if sc.stdout == "" then
+                log.debug("No tag found for " .. url)
                 future.set({})
+            else
+                local latest_tag, latest_version = parser.parse_git_latest_semver_tag(sc.stdout)
+                if latest_tag and latest_version then
+                    future.set({ latest_tag, latest_version })
+                else
+                    log.warn("Could not parse latest tag from: " .. sc.stdout)
+                    future.set({})
+                end
             end
         else
             log.warn(sc.stderr)

--- a/spec/git_spec.lua
+++ b/spec/git_spec.lua
@@ -1,4 +1,5 @@
 local git = require("rocks-git.git")
+local a = require("nio").tests
 
 local origin_pkg_dir = vim.fn.tempname()
 local origin_pkg_remote_dir = vim.fs.joinpath(origin_pkg_dir, ".git", "refs", "remotes", "origin")
@@ -33,5 +34,13 @@ describe("git", function()
             url = "https://github.com/lumen-oss/luarocks-stub.git",
         })
         assert.Same("bar", head_branch)
+    end)
+
+    a.it("Handles a remote without semver tags", function()
+        local url = "https://github.com/lumen-oss/luarocks-stub.git"
+        local version_tuple = git.get_latest_remote_semver_tag(url).wait()
+        vim.print(version_tuple)
+        -- {} if no tag, else latest_tag, latest_version
+        assert.Same({}, version_tuple)
     end)
 end)


### PR DESCRIPTION
My logs were full of scary warnings "Could not parse latest tag from
..".

turns out if a remote repo has no tags, we were trying to decode an
empty string `parser.parse_git_latest_semver_tag(sc.stdout or "")`.
I special cased the empty-string (ie, no remote tags) so it appears as a debug level.

The test was not necessary but I added it while debugging and it doesn't hurt to have it.

I still have illegitimate failures I intend to fix as follow up

```
INFO | 2026-07-27 19:04:31.403 | ...m/start/rocks.nvim/lua/rocks/operations/helpers/init.lua:164 | Installed: menu -> scm
INFO | 2026-07-27 19:04:31.403 | /home/teto/plugins/rocks-git.nvim/lua/rocks-git/git.lua:38 | { "git", "ls-remote", "--tags", "https://github.com/elanmed/fzf-lua-frecency.nvim.git" }
WARN | 2026-07-27 19:04:31.817 | /home/teto/plugins/rocks-git.nvim/lua/rocks-git/git.lua:262 | Usign url https://github.com/elanmed/fzf-lua-frecency.nvim.git
DEBUG | 2026-07-27 19:04:31.818 | /home/teto/plugins/rocks-git.nvim/lua/rocks-git/git.lua:267 | No tag for https://github.com/elanmed/fzf-lua-frecency.nvim.git
INFO | 2026-07-27 19:04:31.821 | /home/teto/plugins/rocks-git.nvim/lua/rocks-git/git.lua:38 | { "git", "checkout", "ref: refs/remotes/up/master", "--force", "--recurse-submodules" }
ERROR | 2026-07-27 19:04:31.849 | /home/teto/plugins/rocks-git.nvim/lua/rocks-git/git.lua:180 | { "Could not checkout HEAD branch", "ref: refs/remotes/up/master", {
    code = 1,
    signal = 0,
    stderr = "erreur : le spécificateur de chemin 'ref: refs/remotes/up/master' ne correspond à aucun fichier connu de git\n",
    stdout = ""
  } }
```