### PR TITLE
fix: dont assume the remote name

### DIFF
--- a/lua/rocks-git/git.lua
+++ b/lua/rocks-git/git.lua
@@ -166,11 +166,12 @@ local function pull(pkg, on_exit)
     })
 end
 
+---Checkout remote default branch
 ---@param pkg rocks-git.Package
 ---@return nio.control.Future
 function git.ensure_head_branch(pkg)
     local future = nio.control.future()
-    local head_branch = git.get_head_branch(pkg)
+    local head_branch = git.get_head_branch(pkg).wait()
     if head_branch then
         checkout(pkg, head_branch, function(sc)
             ---@cast sc vim.SystemCompleted
@@ -217,6 +218,7 @@ local function read_line(path)
     end
 end
 
+---Returns most readable ref: tag > ref > rev
 ---@param pkg rocks-git.Package
 ---@return string | nil rev The git hash or tag that is currently checked out
 function git.get_checked_out_rev(pkg)
@@ -230,18 +232,33 @@ function git.get_checked_out_rev(pkg)
     return tag or read_line(vim.fs.joinpath(git_dir, head_ref))
 end
 
+---Get remote default head branch
 ---@param pkg rocks-git.Package
----@return string | nil head The remote HEAD branch name
+---@return nio.control.Future head The remote HEAD branch name
 function git.get_head_branch(pkg)
-    local git_dir = vim.fs.joinpath(pkg.dir, ".git")
-    local remotes_dir = vim.fs.joinpath(git_dir, "refs", "remotes")
-    return vim.iter(vim.fs.dir(remotes_dir))
-        :map(function(remote_subdir)
-            return read_line(vim.fs.joinpath(remotes_dir, remote_subdir, "HEAD"))
-        end)
-        :find(function(head_file_content)
-            return head_file_content:gsub("ref: refs/remotes/.+/", "")
-        end)
+    local args = { "ls-remote", "--symref", pkg.url, "HEAD" }
+    local future = nio.control.future()
+    local on_exit = function(sc)
+        if sc.code ~= 0 then
+            log.error("an error happened while ls-remote:")
+            log.error(sc.stderr)
+            future.set(false)
+        else
+            local branch = sc.stdout:match("ref:%s+refs/heads/([^%s]+)%s+HEAD")
+            if not branch then
+                log.error("Could not deduce default branch from: %s", sc.stdout)
+                future.set(false)
+            else
+                log.debug("Default remote branch is ", branch)
+                future.set(branch)
+            end
+        end
+    end
+
+    git_cli(args, on_exit, {
+        cwd = pkg.dir,
+    })
+    return future
 end
 
 ---@param url string

--- a/lua/rocks-git/operations.lua
+++ b/lua/rocks-git/operations.lua
@@ -203,6 +203,7 @@ operations.sync = nio.create(function(on_progress, on_error, on_success, pkg)
     end
     local rev = git.get_checked_out_rev(pkg)
     if rev == pkg.rev then
+        log.debug("Already at rev %s: nothing to do", rev)
         return
     else
         on_progress(("rocks-git: %s"):format(pkg.name))

--- a/spec/git_spec.lua
+++ b/spec/git_spec.lua
@@ -1,39 +1,19 @@
 local git = require("rocks-git.git")
 local a = require("nio").tests
 
-local origin_pkg_dir = vim.fn.tempname()
-local origin_pkg_remote_dir = vim.fs.joinpath(origin_pkg_dir, ".git", "refs", "remotes", "origin")
-
-local upstream_pkg_dir = vim.fn.tempname()
-local upstream_pkg_remote_dir = vim.fs.joinpath(upstream_pkg_dir, ".git", "refs", "remotes", "upstream")
+local pkg_dir = vim.fn.tempname()
 
 setup(function()
-    vim.system({ "mkdir", "-p", origin_pkg_remote_dir }, {}):wait()
-    vim.system({ "mkdir", "-p", upstream_pkg_remote_dir }, {}):wait()
-    local origin_head = vim.fs.joinpath(origin_pkg_remote_dir, "HEAD")
-    local fd = assert(io.open(origin_head, "w"), "could not open " .. origin_head)
-    fd:write("foo")
-    fd:close()
-    local upstream_head = vim.fs.joinpath(upstream_pkg_remote_dir, "HEAD")
-    fd = assert(io.open(upstream_head, "w"), "could not open " .. upstream_head)
-    fd:write("bar")
-    fd:close()
+    vim.fn.mkdir(pkg_dir, "p")
 end)
 
 describe("git", function()
-    it("Can get head branch from 'origin' remote", function()
+    a.it("Can get the remote HEAD branch", function()
         local head_branch = git.get_head_branch({
-            dir = origin_pkg_dir,
+            dir = pkg_dir,
             url = "https://github.com/lumen-oss/luarocks-stub.git",
-        })
-        assert.Same("foo", head_branch)
-    end)
-    it("Can get head branch from 'upstream' remote", function()
-        local head_branch = git.get_head_branch({
-            dir = upstream_pkg_dir,
-            url = "https://github.com/lumen-oss/luarocks-stub.git",
-        })
-        assert.Same("bar", head_branch)
+        }).wait()
+        assert.Same("main", head_branch)
     end)
 
     a.it("Handles a remote without semver tags", function()


### PR DESCRIPTION
Problem with the function get_head_branch is that it returns "ref: refs/remotes/...."

```
  return vim.iter(vim.fs.dir(remotes_dir))
      :map(function(remote_subdir)
          return read_line(vim.fs.joinpath(remotes_dir, remote_subdir, "HEAD"))
      end)
      :find(function(head_file_content)
          # this bit isn't visible 
          return head_file_content:gsub("ref: refs/remotes/.+/", "")
      end)


```

and then rocks tries to `git checkout ref: refs/remotes/...` which fails here.

The official way to get the default remote branch is to use  "ls-remote --symref <REMOTE> HEAD".

Since the problem is the default remote varies depending on user config, I skipped it by passing the url:
The advantages are:
- it doesn't depend on user config or wether the user messed up with the repo (unlikely but I sometimes managed in the past to debug plugins in place).
- not implementation dependant

The drawback is that it's one more git call.

Alternatives considered:
- retreive the user default remote via `git config get clone.defaultRemoteName` but this value can be changed after a repo was cloned so not robust enough ()
- trying to hardcode default remote across all git invokations. Can be annoying to implement (and transition from) ?
- fix the current code. But it still wont know what remote to choose in case there are several (it will follow vim.fs.dir order). It's unlikely to be an issue so if that's the preferred solution I can do it as well. The immediate fix that codex was suggesting is this:

```
diff --git a/lua/rocks-git/git.lua b/lua/rocks-git/git.lua
index 6b9bea2828..8851106fbd 100644
--- a/lua/rocks-git/git.lua
+++ b/lua/rocks-git/git.lua
@@ -237,11 +237,13 @@
     local remotes_dir = vim.fs.joinpath(git_dir, "refs", "remotes")
     return vim.iter(vim.fs.dir(remotes_dir))
         :map(function(remote_subdir)
-            return read_line(vim.fs.joinpath(remotes_dir, remote_subdir, "HEAD"))
-        end)
-        :find(function(head_file_content)
-            return head_file_content:gsub("ref: refs/remotes/.+/", "")
-        end)
+            local head_file_content = read_line(vim.fs.joinpath(remotes_dir, remote_subdir, "HEAD"))
+            if not head_file_content then
+                return
+            end
+            return head_file_content:match("^ref: refs/remotes/[^/]+/(.+)$") or head_file_content
+        end)
+        :next()
 end
 ```
 
 
As for the tests, ideally we would run them against a real repo (ie, a clone of https://github.com/lumen-oss/luarocks-stub.git) but cloning this in a _spec.lua file might have been too slow so I didnt do it. Can restore in the test setup() call (a shallow clone)?
